### PR TITLE
Add public API to drive a Generator from an external int source

### DIFF
--- a/src/main/java/org/jetbrains/jetCheck/GenerationEnvironment.java
+++ b/src/main/java/org/jetbrains/jetCheck/GenerationEnvironment.java
@@ -2,6 +2,8 @@ package org.jetbrains.jetCheck;
 
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Objects;
+
 /**
  * A context for {@link Generator}s. Primitive generators (e.g. {@link Generator#integers}) know how to obtain
  * random data from it, other generators build more complex values on top of that, by running {@link #generate(Generator)} recursively.
@@ -15,8 +17,53 @@ public interface GenerationEnvironment {
    * generally less than the original one's.
    */
   int getSizeHint();
-  
+
   /** Runs the given generator on a data sub-structure of this structure and returns the result */
   <T> T generate(@NotNull Generator<T> generator);
-  
+
+  /**
+   * Creates a fresh environment that draws every int from the given source, for producing a value outside
+   * {@link PropertyChecker}. Pass the result to {@link #generate(Generator)} to obtain one value:
+   * <pre>{@code
+   * T value = GenerationEnvironment.generative(source, sizeHint).generate(generator);
+   * }</pre>
+   *
+   * <p>This is an advanced integration point. Ordinary property tests use {@link PropertyChecker#forAll}, which
+   * owns both the source of randomness and the generation loop. Use this factory only to drive a generator from
+   * an external stream of ints — for example a coverage-guided fuzzer that supplies the bytes and wants each of
+   * them to map onto a local change in the generated value. The environment performs generation only; it does not
+   * shrink, replay, or re-run the property.
+   *
+   * <p>Generation draws from {@code source} on demand and reports failures through the same exceptions as a normal
+   * run: an over-constrained generator (such as {@link Generator#suchThat} or {@link Generator#nonEmptyLists} over
+   * a source that cannot satisfy the constraint) throws {@link CannotSatisfyCondition}, which the caller is
+   * expected to handle.
+   *
+   * @param source   the source of the ints every primitive generator draws
+   * @param sizeHint the value returned by {@link #getSizeHint()}, biasing generated collection and string sizes;
+   *                 must be non-negative
+   * @return a fresh environment ready for a single {@link #generate(Generator)} call
+   * @see IntSource
+   */
+  static GenerationEnvironment generative(@NotNull IntSource source, int sizeHint) {
+    Objects.requireNonNull(source, "source");
+    if (sizeHint < 0) throw new IllegalArgumentException("sizeHint must be non-negative: " + sizeHint);
+    GenerativeDataStructure root =
+      new GenerativeDataStructure(source, new StructureNode(new NodeId()), sizeHint, PropertyChecker.DEFAULT_MAX_GENERATION_DEPTH);
+    return new GenerationEnvironment() {
+      @Override
+      public int getSizeHint() {
+        return root.getSizeHint();
+      }
+
+      @Override
+      public <T> T generate(@NotNull Generator<T> generator) {
+        // Run the generator on the root structure, the way a PropertyChecker iteration does, so the top-level
+        // generator sees the full size hint. Calling root.generate(generator) instead would descend into a
+        // sub-structure and hand the generator a hint reduced by one.
+        return generator.getGeneratorFunction().apply(root);
+      }
+    };
+  }
+
 }

--- a/src/main/java/org/jetbrains/jetCheck/IntSource.java
+++ b/src/main/java/org/jetbrains/jetCheck/IntSource.java
@@ -2,8 +2,25 @@
 package org.jetbrains.jetCheck;
 
 /**
- * @author peter
+ * The raw source of the ints that primitive generators draw. Every random decision a {@link Generator} makes
+ * ultimately becomes a {@link #drawInt} call, so an {@code IntSource} is the single point through which all
+ * randomness enters generation.
+ *
+ * <p>This is an advanced integration point. Most tests never touch it: {@link PropertyChecker} supplies its own
+ * source and owns the generation loop. Implement it only to drive a {@link Generator} from an external stream of
+ * ints — for example a coverage-guided fuzzer that mutates a byte stream and wants each mutation to map onto a
+ * local change in the generated value. Pair it with {@link GenerationEnvironment#generative(IntSource, int)}.
+ *
+ * @see GenerationEnvironment#generative(IntSource, int)
  */
-interface IntSource {
+public interface IntSource {
+  /**
+   * Returns the next int, which must satisfy the given distribution (see {@link IntDistribution#isValidValue}).
+   * A bounded distribution should consume only as much of the underlying source as it needs, so that byte-level
+   * changes in the source stay local to the value they affect.
+   *
+   * @param distribution the distribution the returned value must belong to
+   * @return the drawn int
+   */
   int drawInt(IntDistribution distribution);
 }

--- a/src/main/java/org/jetbrains/jetCheck/NodeId.java
+++ b/src/main/java/org/jetbrains/jetCheck/NodeId.java
@@ -18,6 +18,11 @@ class NodeId {
     this(new AtomicInteger(), generator);
   }
 
+  /** A root id not tied to any generator, for a data structure built outside {@link PropertyChecker}. */
+  NodeId() {
+    this(new AtomicInteger(), null);
+  }
+
   private NodeId(AtomicInteger counter, @Nullable Generator<?> generator) {
     this.counter = counter;
     this.generatorHash = generator == null ? null : generator.getGeneratorFunction().hashCode();

--- a/src/test/java/org/jetbrains/jetCheck/GenerationEnvironmentTest.java
+++ b/src/test/java/org/jetbrains/jetCheck/GenerationEnvironmentTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+package org.jetbrains.jetCheck;
+
+import junit.framework.TestCase;
+
+import java.util.List;
+import java.util.Random;
+
+import static java.util.Arrays.asList;
+import static org.jetbrains.jetCheck.Generator.*;
+
+/**
+ * Tests for {@link GenerationEnvironment#generative}, the entry point that drives a {@link Generator} from an
+ * external {@link IntSource} outside {@link PropertyChecker}.
+ */
+public class GenerationEnvironmentTest extends TestCase {
+
+  /** An {@link IntSource} that replays a fixed script and counts how many ints have been drawn. */
+  private static final class ScriptedIntSource implements IntSource {
+    private final int[] values;
+    private int drawn;
+
+    ScriptedIntSource(int... values) {
+      this.values = values;
+    }
+
+    @Override
+    public int drawInt(IntDistribution distribution) {
+      if (drawn >= values.length) {
+        throw new AssertionError("source exhausted after " + values.length + " draws");
+      }
+      return values[drawn++];
+    }
+
+    int drawn() {
+      return drawn;
+    }
+  }
+
+  /** A source that returns 0 for every draw, the counterpart of a fuzzer's all-zero byte seed. */
+  private static IntSource zeros() {
+    return distribution -> 0;
+  }
+
+  /** Adapts a {@link Random} to an {@link IntSource}, the way a caller wires an existing random stream in. */
+  private static IntSource fromRandom(Random random) {
+    return distribution -> distribution.generateInt(random);
+  }
+
+  public void testScriptedSourceDrivesGenerationAndDrawsOneIntPerCall() {
+    // listsOf first draws the size (bounded by the size hint), then one int per element.
+    ScriptedIntSource source = new ScriptedIntSource(3, 10, 20, 30);
+    List<Integer> list = GenerationEnvironment.generative(source, 10).generate(listsOf(integers(0, 100)));
+
+    assertEquals(asList(10, 20, 30), list);
+    // Exactly one draw per int: the size draw plus three element draws, nothing more.
+    assertEquals(4, source.drawn());
+  }
+
+  public void testDifferentIntStreamsProduceDifferentValues() {
+    Generator<List<Integer>> gen = listsOf(integers(0, 100));
+    List<Integer> one = GenerationEnvironment.generative(new ScriptedIntSource(1, 42), 10).generate(gen);
+    List<Integer> two = GenerationEnvironment.generative(new ScriptedIntSource(1, 7), 10).generate(gen);
+
+    assertEquals(asList(42), one);
+    assertEquals(asList(7), two);
+  }
+
+  public void testSameIntSequenceProducesIdenticalValue() {
+    Generator<List<Integer>> gen = listsOf(integers(0, 1000));
+    int[] script = {4, 111, 222, 333, 444};
+    List<Integer> first = GenerationEnvironment.generative(new ScriptedIntSource(script), 20).generate(gen);
+    List<Integer> second = GenerationEnvironment.generative(new ScriptedIntSource(script), 20).generate(gen);
+
+    assertEquals(first, second);
+    assertEquals(asList(111, 222, 333, 444), first);
+  }
+
+  public void testRandomBackedSourceIsDeterministic() {
+    // Two sources over identically seeded Randoms draw the same ints, so they yield the same value.
+    Generator<List<Integer>> gen = listsOf(integers());
+    List<Integer> first = GenerationEnvironment.generative(fromRandom(new Random(123456789L)), 20).generate(gen);
+    List<Integer> second = GenerationEnvironment.generative(fromRandom(new Random(123456789L)), 20).generate(gen);
+
+    assertEquals(first, second);
+  }
+
+  public void testSizeHintReachesTopLevelGenerator() {
+    // The top-level generator observes exactly the requested size hint, as it does under PropertyChecker.
+    Generator<Integer> hint = from(GenerationEnvironment::getSizeHint);
+    assertEquals(7, (int)GenerationEnvironment.generative(zeros(), 7).generate(hint));
+    assertEquals(0, (int)GenerationEnvironment.generative(zeros(), 0).generate(hint));
+  }
+
+  public void testSizeHintBiasesCollectionSizes() {
+    Generator<List<Integer>> gen = listsOf(integers(0, 5));
+    double small = averageSize(gen, 1, 300);
+    double large = averageSize(gen, 40, 300);
+
+    assertTrue("larger size hint should yield larger collections: small=" + small + ", large=" + large,
+               large > small + 3.0);
+  }
+
+  private static double averageSize(Generator<List<Integer>> gen, int sizeHint, int samples) {
+    IntSource source = fromRandom(new Random(20240517L + sizeHint));
+    long total = 0;
+    for (int i = 0; i < samples; i++) {
+      total += GenerationEnvironment.generative(source, sizeHint).generate(gen).size();
+    }
+    return (double)total / samples;
+  }
+
+  public void testCannotSatisfyConditionPropagatesForNonEmptyLists() {
+    // The all-zero source draws size 0 every time, so a non-empty list can never be satisfied.
+    Generator<List<Integer>> gen = nonEmptyLists(integers());
+    try {
+      GenerationEnvironment.generative(zeros(), 16).generate(gen);
+      fail("expected CannotSatisfyCondition");
+    }
+    catch (CannotSatisfyCondition expected) {
+      assertNotNull(expected.getCondition());
+    }
+  }
+
+  public void testCannotSatisfyConditionPropagatesForSuchThat() {
+    Generator<Integer> nonZero = integers(0, 5).suchThat(i -> i != 0);
+    try {
+      GenerationEnvironment.generative(zeros(), 16).generate(nonZero);
+      fail("expected CannotSatisfyCondition");
+    }
+    catch (CannotSatisfyCondition expected) {
+      assertNotNull(expected.getCondition());
+    }
+  }
+
+  public void testNegativeSizeHintRejected() {
+    try {
+      GenerationEnvironment.generative(zeros(), -1);
+      fail("expected IllegalArgumentException");
+    }
+    catch (IllegalArgumentException expected) {
+      assertTrue(expected.getMessage(), expected.getMessage().contains("-1"));
+    }
+  }
+
+  public void testNullSourceRejected() {
+    try {
+      GenerationEnvironment.generative(null, 16);
+      fail("expected NullPointerException");
+    }
+    catch (NullPointerException expected) {
+      // expected
+    }
+  }
+}


### PR DESCRIPTION
## Why

Closes #7.

Generation currently runs only inside `PropertyChecker.forAll(...)`, which owns its own randomness and its own loop. There is no supported way to produce a single value from a `Generator<T>` driven by an *external* source of ints.

A coverage-guided fuzzer (JQF/Zest) needs exactly that: it mutates a byte stream and wants every int a generator draws to come from that stream, so byte-level mutations map onto local, structural changes in the generated value — a much better fit for coverage-guided search than a single seed. Today the JQF integration works around the gap with a class placed inside `org.jetbrains.jetCheck` that reaches package-private internals (`IntSource`, `GenerativeDataStructure`, `StructureNode`, `NodeId`). That pins the integration to a specific jetCheck version — the very reason this issue asks for a supported public API.

## What

A minimal, clearly advanced entry point that reproduces, in public form, what `Iteration` does at the root of a run — wrap a source of ints, build the root data structure, and apply the generator:

- `IntSource` becomes public: `int drawInt(IntDistribution)`.
- `GenerationEnvironment.generative(IntSource, int sizeHint)` — the option-C factory. It returns a fresh environment; call `generate(gen)` on it for one value.

```java
T value = GenerationEnvironment.generative(source, sizeHint).generate(generator);
```

Design notes:

- Each draw goes through the supplied source; a bounded draw consumes only the ints it needs, so byte changes stay local.
- The top-level generator runs on the root structure, so it observes the full `sizeHint` (and `getSizeHint()` returns it), exactly as a `PropertyChecker` iteration does.
- The factory reuses the same maximum recursion depth as a normal run.
- Failures propagate through the existing exceptions. An over-constrained generator over a source that cannot satisfy it (for example `nonEmptyLists` or `suchThat` over an all-zero source) throws `CannotSatisfyCondition`, which the caller handles. jetCheck adds no fuzzer-specific handling and does not special-case `null`.

Tests in `GenerationEnvironmentTest` cover: a known int sequence maps to an expected structure (and each draw consumes exactly one int); different int streams give different values; determinism for a repeated int sequence and a repeated `Random`-backed source; `sizeHint` biases collection sizes; and `CannotSatisfyCondition` propagates for an unsatisfiable constrained generator over an all-zero source.

## Addressing the "too noticeable" concern

You raised the trade-off between a public factory method (small surface, but visible to everyone) and a public implementation class (larger surface). This PR takes the factory side and keeps it out of the way of the majority:

- The entry point lives on `GenerationEnvironment` — which authors of custom generators already meet — not on the front-page `Generator` type.
- `GenerativeDataStructure` and the other internals stay package-private; no implementation class is exposed.
- It is documented as an advanced integration point, and it is not mentioned in the README, so it does not surface to people writing ordinary property tests.

Please pick the final form — the code is easy to reshape. If you would rather trim the surface further, two small follow-ups are natural and I am happy to fold either in or send it separately:

- A `generative(java.util.Random, int sizeHint)` convenience. This is the form easiest to adopt (JQF's stream is already a `java.util.Random`), but it adds a second overload. Left out here to keep this PR to one method.
- A `@FunctionalInterface` annotation on `IntSource`, if you want to guarantee its lambda-target contract. Left out here since the interface already works as a lambda target without it.

## Your read-back question

You asked whether the task also needs access to the data structure or the ints built by a purely random generator run. No — JQF needs only the forward direction: supply the ints, get one value. Zest always supplies the bytes, so it never reads back the ints or the structure a purely random run would produce. The API can stay one-directional.

## Follow-up (not part of this PR)

Once this ships, JQF's `jqf-generator-jetcheck` module can drop its `org.jetbrains.jetCheck.JqfJetCheckBridge` shim and call the public API, unpinning it from a specific jetCheck version.

## How to verify

`mvn test` — the suite passes, including the new `GenerationEnvironmentTest`. `mvn javadoc:javadoc` builds cleanly.
