### PR TITLE
ci: add GitHub Actions workflow to run tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,23 @@
+name: Tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
+        with:
+          distribution: temurin
+          java-version: 25
+          cache: maven
+
+      - run: mvn --batch-mode --no-transfer-progress test

--- a/pom.xml
+++ b/pom.xml
@@ -53,8 +53,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <release>8</release>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,11 @@
     <description>Property-based test framework</description>
     <url>https://github.com/JetBrains/jetCheck</url>
 
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
     <licenses>
       <license>
         <name>The Apache License, Version 2.0</name>
@@ -52,12 +57,17 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.15.0</version>
                 <configuration>
                     <release>8</release>
+                    <compilerArgs>
+                        <arg>-Xlint:-options</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-source-plugin</artifactId>
+                <version>3.4.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -67,6 +77,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.12.0</version>
                 <configuration>
                     <additionalparam>-Xdoclint:all -Xdoclint:-missing</additionalparam>
                 </configuration>


### PR DESCRIPTION
Closes #9.

## Why

There is no CI for the project, so tests are not run automatically on pull requests.

## Sample

Build in my fork https://github.com/vlsi/jetCheck/actions/runs/28525086487

## What

- Add `.github/workflows/tests.yml` that runs `mvn test` on every push to `master` and on pull requests.
- Switch the compiler configuration from `source`/`target` `1.8` to `<release>8</release>` in `pom.xml`. `--release` also swaps in the Java 8 API on the bootclasspath, so building on a newer JDK cannot accidentally pull in a method that is missing on Java 8.

The workflow builds on Temurin JDK 25. Both actions are pinned to full commit SHAs with the tag in a trailing comment (`actions/checkout` v7.0.0, `actions/setup-java` v5.4.0), and `setup-java` handles the Maven dependency cache.

## Notes for the reviewer

- Compiling with `--release 8` prints `source/target value 8 is obsolete` on JDK 25. This is informational, not an error; `--release 8` is still supported. It can be silenced later with `-Xlint:-options` if the warning is unwelcome.
- Build and tests currently run on the same JDK 25. Building on 25 while running the tests on 8/11/17/21 needs Maven toolchains, which I left for a separate change as discussed. A test-only matrix would then come back on top of the toolchain setup.

## How to verify

`mvn --batch-mode --no-transfer-progress test` — 64 tests pass locally on JDK 21 with the `<release>8</release>` change.